### PR TITLE
0.1.3 - Small schema enhancements and SQLAlchemy performance tuning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,22 @@
 Changes
 =======
 
+Release 0.1.3
+=============
+
+Features Added
+--------------
+* Data is now attached to ``ResourceSchema`` as ``loaded_data`` while
+  being loaded. Allows for option of child schemas to see what data the
+  parent is currently loading.
+* Nested objects will no longer trigger an ``"update"`` action when the
+  object has no data provided other than identifying keys.
+
+Bug Fixes
+---------
+* Avoid updating primary key's unnecessarily on loads of existing objects.
+
+
 Release 0.1.2
 =============
 

--- a/drowsy/__init__.py
+++ b/drowsy/__init__.py
@@ -14,4 +14,4 @@ from logging import NullHandler
 logging.getLogger(__name__).addHandler(NullHandler())
 
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/drowsy/schema.py
+++ b/drowsy/schema.py
@@ -198,6 +198,7 @@ class ResourceSchema(Schema, Loggable):
             load_only=load_only,
             dump_only=dump_only,
             partial=partial)
+        self.loaded_data = None
         self.parent_resource = parent_resource
         self.instance = instance
         self._fields_by_data_key = None
@@ -396,11 +397,12 @@ class ResourceSchema(Schema, Loggable):
             taken are not allowed.
 
         """
-        # inherit nested opts from parent if not already set
+        self.loaded_data = data
         many = many if many is not None else self.many
         supplied_action = action
         if not many:
             data = [data]
+        # inherit nested opts from parent if not already set
         self.nested_opts = nested_opts or self.nested_opts
         if (not self.nested_opts and
                 self.parent_resource and
@@ -420,6 +422,7 @@ class ResourceSchema(Schema, Loggable):
         failure = False
         id_data_keys = {self.fields[k].data_key or k for k in self.id_keys}
         for i, obj in enumerate(data):
+            self.loaded_data = obj
             # embeds
             for data_key in obj:
                 field = self.fields_by_data_key.get(data_key)
@@ -456,8 +459,13 @@ class ResourceSchema(Schema, Loggable):
                                 self.instance, pair[0]):
                             new_obj.pop(pair[1])
                     obj = new_obj
-                result = super(ResourceSchema, self).load(
-                    obj, many=False, **kwargs)
+                    result = self.instance  # data only pk, no updates
+                    if len(obj.keys()) > 0:
+                        result = super(ResourceSchema, self).load(
+                            obj, many=False, **kwargs)
+                else:
+                    result = super(ResourceSchema, self).load(
+                        obj, many=False, **kwargs)
                 results.append(result)
             except PermissionValidationError as exc:
                 if many:
@@ -476,6 +484,7 @@ class ResourceSchema(Schema, Loggable):
             results = results[0]
             errors = errors.get(0)
             data = data[0]
+        self.loaded_data = data
         if not failure:
             return results
         else:
@@ -643,14 +652,36 @@ class ModelResourceSchema(ResourceSchema, SQLAlchemyAutoSchema):
         """Deserialize the provided data into a SQLAlchemy object.
 
         :param dict|list<dict> data: Data to be loaded into an instance.
-        :param session: Optional database session. Will be used in place
-            of ``self.session`` if provided.
+        :param bool|None many: `True` if loading a collection. `None`
+            defers to the schema default, other values will act as an
+            override.
         :param instance: SQLAlchemy model instance data should be loaded
             into. If ``None`` is provided at this point or when the
             class was initialized, an instance will either be determined
             using the provided data via :meth:`get_instance`, or if that
             fails a new instance will be created.
+        :param nested_opts: Dictionary of :class:`NestedOpts`, where the
+            top level key is a field name for a nested field, and the
+            value for that key is a :class:`NestedOpts` instance. Used
+            to determine if the entire nested collection is to be
+            replaced, or simply appended to/removed from on load.
+            Overwrites the value set in the schema initializer.
+        :type nested_opts: dict<str, NestedOpts>
+        :param str|None action: Used as part of a permissions check.
+            Possible values include `"create"` if a new object is
+            being created, `"update"` is an existing object is being
+            updated, or `"delete"` if the object is to be deleted.
+            If `None` is provided, the method will deduce the action
+            based on whether an existing instance is found in the
+            database (`"update"`) or not (`"create"`). If loading a
+            collection, any value passed will be applied to all
+            objects.
+        :param session: Optional database session. Will be used in place
+            of ``self.session`` if provided.
         :return: An instance with the provided data loaded into it.
+        :raise ValidationError: If any errors are encountered.
+        :raise PermissionValidationError: If any of the actions being
+            taken are not allowed.
 
         """
         # Adding things to kwargs to play nice with super...


### PR DESCRIPTION
Release 0.1.3
=============

Features Added
--------------
* Data is now attached to ``ResourceSchema`` as ``loaded_data`` while
  being loaded. Allows for option of child schemas to see what data the
  parent is currently loading.
* Nested objects will no longer trigger an ``"update"`` action when the
  object has no data provided other than identifying keys.

Bug Fixes
---------
* Avoid updating primary key's unnecessarily on loads of existing objects.